### PR TITLE
Add Boostrap Non Sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,5 @@ This can be easily done, as is in this repository's
 ## TODO
 
 * Add a hook that acts as a boostrap
-  * curl's the bootstrap script
-  * tells the user to run it as sudo
-* Make flag for bootstrap allowing `poetry install` to be done without sudo
-  * change `setup_hooks.sh` so `run_bootstrap()` uses the non-sudo flags
-  * don't want it failing every time a repo is cloned
+   * curl's the bootstrap script
+   * tells the user to run it as sudo

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,12 +9,29 @@ readonly REPO_TOP_DIR="$(realpath ${SCRIPT_DIR_PATH})"
 readonly ORIGINAL_USER=${SUDO_USER}
 readonly RUN_PREFIX="sudo runuser ${ORIGINAL_USER} --command"
 
+# Don't make a dependency file because I want this script to be self-contained
 declare -a DEPENDECY_LIST=(
     ruby
     gh
     pre-commit=2.17.0-1
 
 )
+
+function usage {
+    cat << EOF
+$(basename "${0}"): Bootstraps the devops environment
+General: sudo ./$(basename "${0}") [Optional]
+    This is how you should run the script unless you are installing JUST --no-sudo.
+Setup pre-commit: ./$(basename "${0}") --no-sudo
+
+Required Args:
+    None
+Optional Args:
+    --no-sudo: Set this flag if you are setting up pre-commit.
+        You are guaranteeing NO command requiring sudo will be executed.
+    -h | --help: Print this message
+EOF
+}
 
 # $1 = The package to install (if it isn't already)
 function check_if_sudo(){
@@ -26,21 +43,20 @@ function check_if_sudo(){
         else
             echo -e "\nThe bootstrap script MUST be run as root."
         fi
-        echo -e "Please run sudo ${SCRIPTPATH}\n"
+        echo -e "Please run \tsudo .${SCRIPTPATH}"
+        echo -e "Or \t\t.${SCRIPTPATH} --help\n"
         exit
     fi
 }
 
 # There are packages / modules which MUST be installed at the user level
-# As this script MUST also be a sudoer for system level installs, this causes
-#   and issue.
+# As this script is often also a sudoer for system level installs, this causes
+#   an issue.
 # Using the runuser command, it is possible to run commands at the user
 #   level again.
 # $1 = command_to_run
 function run_cmd_as_user(){
     local -r command_to_run="$1"
-
-    local -r expected_poetry_loc="/home/${ORIGINAL_USER}/.local/bin/poetry"
 
     echo "${command_to_run}"
     ${RUN_PREFIX}="${command_to_run}"
@@ -79,6 +95,7 @@ function install_pkg(){
     else
         local -r current_version=$(get_installed_version ${pkg_to_install})
         if [[ "${version}" != "default" && "${current_version}" != ${version} ]]; then
+            check_if_sudo ${pkg_to_install}
             sudo ${pkg_manager} remove -y ${pkg_to_install}
             sudo ${pkg_manager} install -y ${pkg_to_install}=${version}
         fi
@@ -92,51 +109,74 @@ function install_pkg(){
 function install_mdl(){
     if ! command -v mdl &> /dev/null
     then
+        check_if_sudo "mdl via gem"
         echo "gem install mdl"
         sudo gem install mdl
     fi
 
 }
 
+# $1 = sudo_allowed. true = sudoer. false = regular user.
+# $2 = user - the name of the actual user
+# Return - The current poetry version (if it is installed)
+function get_current_poetry_version() {
+    local -r sudo_allowed=$1
+    local -r user=$2
+    local -r expected_poetry_loc="/home/${user}/.local/bin/poetry"
+    local -r get_poetry_version_cmd="python -m poetry --version --no-ansi"
+    local raw_actual_poetry_version=""
+
+    if [[ ! -f ${expected_poetry_loc} ]]; then
+        echo "Poetry is not installed!"
+        return
+    fi
+
+
+    if [[ ${sudo_allowed} == true ]]; then
+        raw_actual_poetry_version=$(run_cmd_as_user "${get_poetry_version_cmd}")
+    else
+        raw_actual_poetry_version=$(${get_poetry_version_cmd})
+    fi
+
+    # Trim down the version to what we care about
+    local actual_poetry_version="$(echo ${raw_actual_poetry_version} | sed -e  's/.*(version\(.*\)*./\1/' )"
+    actual_poetry_version="$(echo ${actual_poetry_version} | tr -d ' \t\n\r ' )"
+    echo "${actual_poetry_version}"
+}
+
+# $1 = sudo_allowed. true = sudoer. false = regular user.
+# $2 = user - the name of the actual user
 function install_poetry()
 {
+    local -r sudo_allowed=$1
+    local -r user=$2
     local -r expected_poetry_version="1.2.2"
 
-    # Release sudo for this to work -> become user again
-    local -r original_user=${SUDO_USER}
-    local -r expected_poetry_loc="/home/${original_user}/.local/bin/poetry"
-
-    local actual_poetry_version=""
-    if [[ -f ${expected_poetry_loc} ]]; then
-        local -r get_poetry_version="python -m poetry --version --no-ansi"
-        actual_poetry_version=$(run_cmd_as_user "${get_poetry_version}")
-        actual_poetry_version="$(echo ${actual_poetry_version} | sed -e  's/.*(version\(.*\)*./\1/' )"
-        actual_poetry_version="$(echo ${actual_poetry_version} | tr -d ' \t\n\r ' )"
-    fi
-
-    local -r uninstall_poetry_cmd="python -m pip uninstall -y poetry"
-    local -r install_poetry_cmd="python -m pip install poetry==${expected_poetry_version}"
-    local -r setup_poetry_config="python -m poetry config --ansi virtualenvs.in-project true"
-
-
-    if [[ "${actual_poetry_version}" != "${expected_poetry_version}" ]];
-    then
-        echo "Poetry version mismatch!"
-        echo "Expected: ${expected_poetry_version}. Actual: ${actual_poetry_version}"
-        echo "Installing the correct version."
-        run_cmd_as_user "${uninstall_poetry_cmd}"
-        run_cmd_as_user "${install_poetry_cmd}"
+    # https://python-poetry.org/docs/
+    local -r curl_cmd="curl -sSL https://install.python-poetry.org"
+    local -r install_script_cmd="python3 - --version ${expected_poetry_version}"
+    local -r install_cmd="${curl_cmd} | ${install_script_cmd}"
+    if [[ ${sudo_allowed} == true ]]; then
+        run_cmd_as_user "${install_cmd}"
     else
-        echo "Poetry is installed correctly"
+        ${curl_cmd} | ${install_script_cmd}
     fi
-manual
-    run_cmd_as_user "${setup_poetry_config}"
-
 }
 
 # Some python packages must be installed via pip
+# $1 = sudo_allowed. true = sudoer. false = regular user.
+# $2 = user - the name of the actual user
 function install_python_dep() {
-    install_poetry
+    local -r sudo_allowed=$1
+    local -r user=$2
+    install_poetry ${sudo_allowed}
+
+    local -r setup_poetry_config="python -m poetry config --ansi virtualenvs.in-project true"
+    if [[ ${sudo_allowed} == true ]]; then
+        run_cmd_as_user "${setup_poetry_config}"
+    else
+        ${setup_poetry_config}
+    fi
 }
 
 function install_rust_deps() {
@@ -154,40 +194,79 @@ function install_rust_deps() {
 }
 
 # $1 = pkg_manager - the pkg manager of the system
+# $2 = sudo_allowed. true = sudoer. false = regular user.
 function check_dependencies() {
     local -r pkg_manager=$1
+    local -r sudo_allowed=$2
     local -r dependencies_file="${REPO_TOP_DIR}/dependencies.txt"
     local -r dependencies=
 
-    sudo ${pkg_manager} install -y "${DEPENDECY_LIST[@]}"
+
+    if [[ ${sudo_allowed} == true ]]; then
+        check_if_sudo
+        sudo ${pkg_manager} install -y "${DEPENDECY_LIST[@]}"
+
+        # Need Ruby package manager to get mdl - markdown linter
+        install_mdl
+    fi
+
+    local user=${USER}
+    if [[ ${sudo_allowed} == true ]]; then
+        user=${SUDO_USER}
+    fi
 
     install_rust_deps
-    install_python_dep
-
-    # Need Ruby package manager to get mdl - markdown linter
-    install_mdl
+    install_python_dep ${sudo_allowed} ${user}
 }
 
+# $2 = sudo_allowed. true = sudoer. false = regular user.
 function create_venv() {
-    run_cmd_as_user "python -m poetry install"
+    local -r sudo_allowed=$1
+    create_poetry_venv_cmd="python -m poetry install"
+    if [[ ${sudo_allowed} == true ]]; then
+        run_cmd_as_user "${create_poetry_venv_cmd}"
+    else
+        ${create_poetry_venv_cmd}
+    fi
 }
 
+# Args: all args from script entry = "$@"
 function main() {
-    check_if_sudo
-    
+    local sudo_allowed=true
+
+    while [[ $# -gt 0 ]]; do
+        arg="$1";
+        shift;
+        case ${arg} in
+            "-h" | "--help")
+                usage
+                exit
+                ;;
+            "--no-sudo" )
+                sudo_allowed="false"
+                shift
+                ;;
+            * )
+                echo -e >&2 "Unexpected argument: ${arg}\n";
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
     local pkg_manager=""
     if [ -x "$(command -v apt)" ]; then pkg_manager="apt"
     elif [ -x "$(command -v dnf)" ];     then pkg_manager="dnf"
     fi
 
-    check_dependencies ${pkg_manager}
+    check_dependencies ${pkg_manager} ${sudo_allowed}
 
     local -r bashrc_loc="$HOME/.bashrc"
     if [[ -f ${bashrc_loc} ]]; then
         source "${bashrc_loc}"
     fi
 
-    create_venv
+    create_venv ${sudo_allowed}
 }
 
-main
+main "$@"

--- a/hooks/setup_hooks.sh
+++ b/hooks/setup_hooks.sh
@@ -48,7 +48,7 @@ function copy_pre_commit_config() {
 function setup_pre_commit() {
     local -r repo_top_dir="$1"
     copy_pre_commit_config ${repo_top_dir}
-    pre-commit install
+    (cd ${repo_top_dir} && pre-commit install --hook-type pre-push)
 }
 
 # $1 = top level dir of repo
@@ -79,7 +79,9 @@ function setup_cloned_repo() {
 }
 
 function run_bootstrap() {
-    (cd "${DEVOPS_TOP_DIR}" && ./bootstrap.sh)
+    # Run with no-sudo to make sure sudo will NEVER be required for a command
+    # Prevents weird control flow for end-users when cloning a respository
+    (cd "${DEVOPS_TOP_DIR}" && ./bootstrap.sh --no-sudo)
 }
 
 function main() {


### PR DESCRIPTION
Add the `--no-sudo` flag to `bootstrap.sh`. 

This flag will allow the script to be run without sudo. Previously the only way to run it was with sudo as some command required it. With the addition of the flag, commands can be group together based on whether they require sudo permissions or not. 

When the `--no-sudo` flag is given, only commands that do not require sudo are run. This is very useful when running bootstrap for a newly cloned repo, and the system as a whole is boostraped (i.e. rust is installed).

The `setup_hooks.sh` script makes use of this flag, so using it in cloned repos will work out of the box.